### PR TITLE
Launching single devices

### DIFF
--- a/plugin/src/main/groovy/com/genymotion/GenymotionGradlePlugin.groovy
+++ b/plugin/src/main/groovy/com/genymotion/GenymotionGradlePlugin.groovy
@@ -23,13 +23,10 @@ import com.genymotion.model.GenymotionConfig
 import com.genymotion.model.VDLaunchDsl
 import com.genymotion.model.VDLaunchDslFactory
 import com.genymotion.tasks.GenymotionFinishTask
-import com.genymotion.tasks.GenymotionLaunchTask
 import com.genymotion.tasks.GenymotionSingleLaunchTask
 import com.genymotion.tools.GMTool
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.internal.reflect.Instantiator
 
 import javax.inject.Inject
@@ -55,10 +52,6 @@ class GenymotionGradlePlugin implements Plugin<Project> {
         project.extensions.create('genymotion', GenymotionPluginExtension, project, devicesLaunch)
         project.genymotion.extensions.create('config', GenymotionConfig)
 
-        project.task(TASK_LAUNCH, type: GenymotionLaunchTask) {
-            description 'Starting task for Genymotion plugin'
-            group PLUGIN_GROUP
-        }
         project.task(TASK_FINISH, type: GenymotionFinishTask) {
             description 'Finishing task for Genymotion plugin'
             group PLUGIN_GROUP
@@ -73,7 +66,6 @@ class GenymotionGradlePlugin implements Plugin<Project> {
             project.genymotion.checkParams()
             project.genymotion.injectTasks()
 
-
             project.genymotion.getDevices().each {
                 def task = project.task(TASK_LAUNCH + it.name.capitalize(), type: GenymotionSingleLaunchTask) {
                     description 'Starting task for device ' + it.name
@@ -81,7 +73,11 @@ class GenymotionGradlePlugin implements Plugin<Project> {
                 }
 
                 task.device = it
+            }
 
+            project.task(TASK_LAUNCH, dependsOn: project.tasks.withType(GenymotionSingleLaunchTask)) {
+                description 'Starting task for Genymotion plugin'
+                group PLUGIN_GROUP
             }
         }
     }

--- a/plugin/src/main/groovy/com/genymotion/GenymotionGradlePlugin.groovy
+++ b/plugin/src/main/groovy/com/genymotion/GenymotionGradlePlugin.groovy
@@ -24,9 +24,12 @@ import com.genymotion.model.VDLaunchDsl
 import com.genymotion.model.VDLaunchDslFactory
 import com.genymotion.tasks.GenymotionFinishTask
 import com.genymotion.tasks.GenymotionLaunchTask
+import com.genymotion.tasks.GenymotionSingleLaunchTask
 import com.genymotion.tools.GMTool
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.internal.reflect.Instantiator
 
 import javax.inject.Inject
@@ -70,6 +73,16 @@ class GenymotionGradlePlugin implements Plugin<Project> {
             project.genymotion.checkParams()
             project.genymotion.injectTasks()
 
+
+            project.genymotion.getDevices().each {
+                def task = project.task(TASK_LAUNCH + it.name.capitalize(), type: GenymotionSingleLaunchTask) {
+                    description 'Starting task for device ' + it.name
+                    group PLUGIN_GROUP
+                }
+
+                task.device = it
+
+            }
         }
     }
 }

--- a/plugin/src/main/groovy/com/genymotion/tasks/GenymotionSingleLaunchTask.groovy
+++ b/plugin/src/main/groovy/com/genymotion/tasks/GenymotionSingleLaunchTask.groovy
@@ -1,0 +1,38 @@
+package com.genymotion.tasks
+
+import com.genymotion.model.GenymotionVirtualDevice
+import com.genymotion.tools.GMTool
+import com.genymotion.tools.Log
+import org.gradle.api.tasks.TaskAction
+
+
+class GenymotionSingleLaunchTask extends GenymotionLaunchTask {
+
+    def device
+
+    @TaskAction
+    def exec() {
+
+        if (project.genymotion.config.verbose) {
+            Log.info("Starting devices")
+        }
+
+        def runningDevices = []
+
+        def virtualDevices = GMTool.getAllDevices(project.genymotion.config.verbose, false, false)
+        virtualDevices.each {
+            if (it.state == GenymotionVirtualDevice.STATE_ON) {
+                runningDevices.add(it.name)
+            }
+        }
+
+        def virtualDevicesNames = virtualDevices*.name
+
+        processDevice(device, runningDevices, virtualDevicesNames)
+
+        if (project.genymotion.config.verbose) {
+            Log.debug("-- Running devices --")
+            GMTool.getRunningDevices(true)
+        }
+    }
+}


### PR DESCRIPTION
Instead of launching all devices from the configuration I think it's better to split the task into smaller steps. Each small task starts one device. At the end create a master tasks which combine them.

still WIP!
