### PR TITLE
Use gmtool after configuration has been done

### DIFF
--- a/plugin/src/main/groovy/com/genymotion/GenymotionPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/genymotion/GenymotionPluginExtension.groovy
@@ -241,17 +241,12 @@ class GenymotionPluginExtension {
     /**
      * Configuration management
      */
-
     def processConfiguration(GMTool gmtool = GMTool.newInstance()) {
-        project.genymotion.config.version = gmtool.getVersion()
-
         GenymotionConfig config = project.genymotion.config
         config.applyConfigFromFile(project)
-
+        project.genymotion.config.version = gmtool.getVersion()
         if (!config.isEmpty()) {
-
             gmtool.setConfig(config)
-
             if (config.license) {
                 gmtool.setLicense(config.license)
             }


### PR DESCRIPTION
In order to be able to use the plugin with configuration in the local.properties and without putting gmtool in the path, move some codes to be sure gmtool has been configured before using it to retrieve its version.

It works on my side for my use case, please review this to be sure there is no side effect I missed.